### PR TITLE
fix(eventhandler): fixed exception "Unable to parse URI" when executing from cli

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -19,8 +19,8 @@ class bx_otel extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.0.0";
-        $this->MODULE_VERSION_DATE = "2025-03-25 00:00:00";
+        $this->MODULE_VERSION = "1.1.2";
+        $this->MODULE_VERSION_DATE = "2025-06-24";
         $this->MODULE_NAME = "BxOtel";
         $this->MODULE_DESCRIPTION = "Bitrix модуль для сбора метрик на событиях OnPageStart";
     }

--- a/lib/event/eventhandler.php
+++ b/lib/event/eventhandler.php
@@ -86,6 +86,10 @@ class EventHandler
         }
 
         $bxRequest = Application::getInstance()->getContext()->getRequest();
+        if (empty($bxRequest->getServer()->get('HTTP_HOST'))) {
+            return;
+        }
+
         $psrRequest = new ServerRequest($bxRequest);
         if (!static::isAllowRequest($psrRequest)) {
             return;


### PR DESCRIPTION
Когда скрипт запускается с помощью cron или вручную из cli, возникает ошибка, которая в том числе приводит к неработоспособности всех агентов на сайте, если они запускаются под кроном.
Это происходит, потому что у нас не задан $_SERVER['HTTP_HOST']. Добавлена обработка для таких ситуаций, чтобы событие завершалось при пустом значении $_SERVER['HTTP_HOST'].

Exception trace:
`[GuzzleHttp\Psr7\Exception\MalformedUriException] 
Unable to parse URI: http:// (0)
/var/www/bitrix/local/vendor/guzzlehttp/psr7/src/Uri.php:85
#0: GuzzleHttp\Psr7\Uri-&gt;__construct(string)
        /var/www/bitrix/local/vendor/beta/bitrix-psr7/src/Message.php:50
#1: BitrixPSR7\Message-&gt;__construct(object)
        /var/www/bitrix/local/modules/bx.otel/lib/event/eventhandler.php:89
#2: Bx\Otel\Event\EventHandler::onStart()
        /var/www/bitrix/bitrix/modules/main/classes/general/module.php:483
#3: ExecuteModuleEventEx(array)
        /var/www/bitrix/bitrix/modules/main/include.php:185
#4: require_once(string)
        /var/www/bitrix/bitrix/modules/main/include/prolog_before.php:19
#5: require(string)
        /var/www/bitrix/local/php_interface/cron_events.php:9`